### PR TITLE
#3 Update package list before imagemagick install

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apt-get -y install imagemagick
+apt-get update && apt-get -y install imagemagick
 IMAGE_URL=$(curl http://metadata/computeMetadata/v1/instance/attributes/url -H "X-Google-Metadata-Request: True")
 TEXT=$(curl http://metadata/computeMetadata/v1/instance/attributes/text -H "X-Google-Metadata-Request: True")
 CS_BUCKET=$(curl http://metadata/computeMetadata/v1/instance/attributes/cs-bucket -H "X-Google-Metadata-Request: True")


### PR DESCRIPTION
I was having the same problem as @drewbryant when running through the python compute demo. Connecting to my compute vm with SSH and manually running 'sudo apt-get install imagemagick' I was seeing 'E: Package 'imagemagick' has no installation candidate'. So I tried updating apt's package index using 'sudo apt-get update' and everything worked. 

Finally, I went back and tried adding the package update to startup.sh and ran the whole demo again. This time the final image showed up correctly at the expected gcs bucket url.
