### PR TITLE
Fix startup script to create GS bucket

### DIFF
--- a/startup-script.sh
+++ b/startup-script.sh
@@ -29,7 +29,10 @@ cd image-output
 wget $IMAGE_URL
 convert * -pointsize 30 -fill white -stroke black -gravity center -annotate +10+40 "$TEXT" output.png
 
-# Store the image in Google Cloud Storage and allow all users
+# Create a Google Cloud Storage bucket.
+gsutil mb gs://$CS_BUCKET
+
+# Store the image in the Google Cloud Storage bucket and allow all users
 # to read it.
 gsutil cp -a public-read output.png gs://$CS_BUCKET/output.png
 


### PR DESCRIPTION
Added a `gsutil mb` step to the script. The `gsutil cp` command does not automatically create a bucket if it doesn't exist.

Unless the user has a bucket already named with their project ID, the image is never uploaded and the user is never notified that there is an issue.